### PR TITLE
Correct Gradient Computation and add specular lighting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,6 @@ if(APPLE)
 endif()
 
 find_package(ParaView 4.4 REQUIRED COMPONENTS vtkPVCatalyst vtkPVVTKExtensionsDefault vtkPVClientServerCoreCore)
-if(NOT PARAVIEW_USE_MPI)
-  message(SEND_ERROR "ParaView must be built with MPI enabled")
-endif()
 include("${PARAVIEW_USE_FILE}")
 include(ParaViewPlugins)
 
@@ -35,6 +32,10 @@ if(${CLIENT_OR_SERVER} STREQUAL Server)
 endif()
 
 if (BuildServerLibs)
+  if(NOT PARAVIEW_USE_MPI)
+    message(SEND_ERROR "ParaView must be built with MPI enabled")
+  endif()
+
   find_package(MPI REQUIRED)
   include_directories(${MPI_INCLUDE_PATH})
 

--- a/Source/PyFR/Gradients.h
+++ b/Source/PyFR/Gradients.h
@@ -68,7 +68,7 @@ struct ComputeGradients : public vtkm::worklet::WorkletMapCellToPoint
   typedef vtkm::Vec<FPType,8> GradientField;
   typedef vtkm::Vec< vtkm::Vec<FPType,3>,8> VecField;
 
-  ComputeGradients(vtkm::cont::CellSetSingleType<StorageTag> cellset,
+  ComputeGradients(vtkm::cont::CellSetSingleType<StorageTag>& cellset,
                    PyFRData::Vec3ArrayHandle coords,
                    PyFRData::ScalarDataArrayHandle density,
                    PyFRData::ScalarDataArrayHandle pressure,
@@ -378,8 +378,11 @@ public:
     return cellSet.CastAndCall(run);
   }
 
+  //we need to create a copy of the cellset here!
+  //this is needed as we are going to possible recompute the
+  //member variable NumberOfPoints
   template <typename StorageTag, typename DeviceTag>
-  void Run(const vtkm::cont::CellSetSingleType<StorageTag>& cellSet,
+  void Run(vtkm::cont::CellSetSingleType<StorageTag> cellSet,
            const vtkm::cont::DataSet& input,
            vtkm::cont::ArrayHandle<FPType>& densityGradientMag,
            vtkm::cont::ArrayHandle<FPType>& pressureGradientMag,

--- a/Source/PyFR/MergePoints.h
+++ b/Source/PyFR/MergePoints.h
@@ -205,7 +205,9 @@ public:
       outputConnectivity, pointLess);
 
     vtkm::cont::CellSetSingleType<> outputCellSet(
-      vtkm::CellShapeTagHexahedron(), "cells");
+      vtkm::CellShapeTagHexahedron(),
+      output_points.GetNumberOfValues(),
+      "cells");
     outputCellSet.Fill(outputConnectivity);
     output.AddCellSet(outputCellSet);
 

--- a/Source/PyFR/PyFRData.cu
+++ b/Source/PyFR/PyFRData.cu
@@ -101,7 +101,9 @@ void PyFRData::Init(void* data)
       Copy(cast, connectivity);
     }
 
-  vtkm::cont::CellSetSingleType<> cset(vtkm::CellShapeTagHexahedron(), "cells");
+  vtkm::cont::CellSetSingleType<> cset(vtkm::CellShapeTagHexahedron(),
+                                       meshData->nCells*meshData->nVerticesPerCell,
+                                       "cells");
   cset.Fill(connectivity);
 
   StridedDataFunctor stridedDataFunctor[5];

--- a/Source/PyFR/PyFRGradientFilter.cu
+++ b/Source/PyFR/PyFRGradientFilter.cu
@@ -65,17 +65,13 @@ PyFRGradientFilter::operator()(PyFRData* inputData, PyFRData* outputData)
     QUADRATIC = 2
   };
   vtkm::cont::Field dgrad("density_gradient_magnitude", LINEAR,
-    vtkm::cont::Field::ASSOC_POINTS,
-    vtkm::cont::DynamicArrayHandle(densityGradientMag));
+    vtkm::cont::Field::ASSOC_POINTS, densityGradientMag);
   vtkm::cont::Field pgrad("pressure_gradient_magnitude", LINEAR,
-    vtkm::cont::Field::ASSOC_POINTS,
-    vtkm::cont::DynamicArrayHandle(pressureGradientMag));
+    vtkm::cont::Field::ASSOC_POINTS, pressureGradientMag);
   vtkm::cont::Field vgrad("velocity_gradient_magnitude", LINEAR,
-    vtkm::cont::Field::ASSOC_POINTS,
-    vtkm::cont::DynamicArrayHandle(velocityGradientMag));
+    vtkm::cont::Field::ASSOC_POINTS, velocityGradientMag);
   vtkm::cont::Field qcriterion("velocity_qcriterion", LINEAR,
-    vtkm::cont::Field::ASSOC_POINTS,
-    vtkm::cont::DynamicArrayHandle(velocityQCriterion));
+    vtkm::cont::Field::ASSOC_POINTS, velocityQCriterion);
 
   output.AddField(dgrad);
   output.AddField(pgrad);

--- a/Source/PyFRStub/PyFRContourFilter.h
+++ b/Source/PyFRStub/PyFRContourFilter.h
@@ -21,5 +21,13 @@ struct PyFRContourFilter
       std::numeric_limits<float>::signaling_NaN()
     );
   }
+  const std::pair<FPType,FPType> DataRange() const {
+    return std::make_pair(std::numeric_limits<float>::min(),
+                          std::numeric_limits<float>::max());
+  }
+  const std::pair<FPType,FPType> ColorRange() const {
+    return std::make_pair(std::numeric_limits<float>::min(),
+                          std::numeric_limits<float>::max());
+  }
 };
 #endif

--- a/Source/vtkPyFR/CMakeLists.txt
+++ b/Source/vtkPyFR/CMakeLists.txt
@@ -66,10 +66,11 @@ if (BuildServerLibs)
 endif()
 
 if (BuildClientLibs)
+  find_package(OpenGL REQUIRED)
   add_paraview_plugin(pyfr_plugin "1.0" SERVER_MANAGER_XML PyFR.xml SERVER_MANAGER_SOURCES ${vtkPyFR_SRCS})
   set_target_properties(pyfr_plugin PROPERTIES COMPILE_FLAGS "-DFPType=double")
   target_include_directories(pyfr_plugin PUBLIC ${PROJECT_SOURCE_DIR}/Source/PyFRStub)
-  target_link_libraries(pyfr_plugin PRIVATE vtkPVCatalyst vtkPVVTKExtensionsDefault vtkPVClientServerCoreCore)
+  target_link_libraries(pyfr_plugin PRIVATE vtkPVCatalyst vtkPVVTKExtensionsDefault vtkPVClientServerCoreCore ${OPENGL_LIBRARIES})
   list( APPEND vtkPyFRLibs pyfr_plugin )
 endif()
 

--- a/Source/vtkPyFR/PyFR.xml
+++ b/Source/vtkPyFR/PyFR.xml
@@ -23,7 +23,7 @@
           name="ContourField"
           command="SetContourField"
           number_of_elements="1"
-          default_values="1">
+          default_values="0">
         <EnumerationDomain name="enum">
           <Entry value="0" text="Density"/>
           <Entry value="1" text="Pressure"/>

--- a/Source/vtkPyFR/vtkPyFRAdaptor.cxx
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.cxx
@@ -81,9 +81,10 @@ void* CatalystInitialize(char* hostName, int pyport, char* outputfile, void* p)
   return data;
 }
 
-extern "C" void
-CatalystCamera(void* p, const float eye[3], const float ref[3],
-               const float vup[3]) {
+//----------------------------------------------------------------------------
+void CatalystCamera(void* p, const float eye[3], const float ref[3],
+               const float vup[3])
+{
   vtkPyFRData* data = static_cast<vtkPyFRData*>(p);
   std::copy(eye, eye+3, data->GetData()->eye);
   std::copy(ref, ref+3, data->GetData()->ref);
@@ -92,14 +93,16 @@ CatalystCamera(void* p, const float eye[3], const float ref[3],
 
 /// Sets the background color for the render window.
 /// @param color 3-tuple of RGB color values, each in [0,1].
-extern "C" void
-CatalystBGColor(void* p, const float color[3]) {
+//----------------------------------------------------------------------------
+void CatalystBGColor(void* p, const float color[3])
+{
   vtkPyFRData* data = static_cast<vtkPyFRData*>(p);
   std::copy(color, color+3, data->GetData()->bg_color);
 }
 
-extern "C" void
-CatalystImageResolution(void*, const uint32_t imgsz[2]) {
+//----------------------------------------------------------------------------
+void CatalystImageResolution(void*, const uint32_t imgsz[2])
+{
   if(Processor == NULL)
     {
     fprintf(stderr, "%s: Catalyst not initialized!\n", __FUNCTION__);

--- a/Source/vtkPyFR/vtkPyFRAdaptor.cxx
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.cxx
@@ -114,6 +114,19 @@ void CatalystImageResolution(void*, const uint32_t imgsz[2])
 }
 
 //----------------------------------------------------------------------------
+void CatalystSpecularLighting(void*, float coefficient, float power)
+{
+  if(Processor == NULL)
+    {
+    fprintf(stderr, "%s: Catalyst not initialized!\n", __FUNCTION__);
+    return;
+    }
+  vtkPyFRPipeline* pipeline =
+    vtkPyFRPipeline::SafeDownCast(Processor->GetPipeline(0));
+  pipeline->SetSpecularLighting(coefficient, power);
+}
+
+//----------------------------------------------------------------------------
 void CatalystFinalize(void* p)
 {
   vtkPyFRData* data = static_cast<vtkPyFRData*>(p);

--- a/Source/vtkPyFR/vtkPyFRAdaptor.h
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.h
@@ -16,7 +16,7 @@ extern "C"
 
   void CatalystBGColor(void* p, const float color[3]);
 
-  void CatalystImageResolution(void* p, const float color[3]);
+  void CatalystImageResolution(void* p, const uint32_t imgsz[2]);
 
   //By default all items use a coefficient of 0.5 and a power of 25
   //coefficient of 0 turns of specular highlights

--- a/Source/vtkPyFR/vtkPyFRAdaptor.h
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.h
@@ -10,6 +10,13 @@ extern "C"
   void CatalystFinalize(void* p);
 
   void CatalystCoProcess(double time, unsigned int timeStep, void* p, bool lastTimeStep=false);
+
+  void CatalystCamera(void* p, const float eye[3], const float ref[3],
+                      const float vup[3]);
+
+  void CatalystBGColor(void* p, const float color[3]);
+
+  void CatalystImageResolution(void* p, const float color[3]);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/vtkPyFR/vtkPyFRAdaptor.h
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.h
@@ -17,6 +17,11 @@ extern "C"
   void CatalystBGColor(void* p, const float color[3]);
 
   void CatalystImageResolution(void* p, const float color[3]);
+
+  //By default all items use a coefficient of 0.5 and a power of 25
+  //coefficient of 0 turns of specular highlights
+  //power is 0 - 100
+  void CatalystSpecularLighting(void* p, float coefficient, float power);
 #ifdef __cplusplus
 }
 #endif

--- a/Source/vtkPyFR/vtkPyFRPipeline.cxx
+++ b/Source/vtkPyFR/vtkPyFRPipeline.cxx
@@ -317,7 +317,7 @@ PV_PLUGIN_IMPORT(pyfr_plugin_fp64)
   vtkSMPropertyHelper(this->Contour, "Input").Set(gradients, 0);
 #endif
   vtkSMPropertyHelper(this->Contour,"ContourField").Set(0);
-  vtkSMPropertyHelper(this->Contour,"ColorField").Set(0);
+  vtkSMPropertyHelper(this->Contour,"ColorField").Set(8);
 
   // Set up the isovalues to use.
   const PyFRData* dta = pyfrData->GetData();

--- a/Source/vtkPyFR/vtkPyFRPipeline.cxx
+++ b/Source/vtkPyFR/vtkPyFRPipeline.cxx
@@ -96,6 +96,19 @@ reduce(T* v, size_t n, vtkCommunicator::StandardOperations op) {
     comm->Reduce(v, NULL, n, op, dest);
   }
 }
+
+
+static void
+output_camera(/*const*/ vtkCamera* cam) {
+  double eye[3] = {0.0};
+  double ref[3] = {0.0};
+  double vup[3] = {0.0};
+  cam->GetPosition(eye);
+  cam->GetFocalPoint(ref);
+  cam->GetViewUp(vup);
+  printf("eye={%lg %lg %lg} ref={%lf %lf %lf} vup={%lf %lf %lf}\n",
+         eye[0],eye[1],eye[2], ref[0],ref[1],ref[2],
+         vup[0],vup[1],vup[2]);
 }
 
 template <class Mapper>
@@ -125,6 +138,9 @@ void vtkUpdateFilter(vtkSMSourceProxy* filter, double time)
 {
   std::cout << "filter: " << filter->GetClassName() << " update to time: " << time << std::endl;
   filter->UpdatePipeline(time);
+}
+
+
 }
 
 vtkStandardNewMacro(vtkPyFRPipeline);
@@ -472,19 +488,7 @@ int vtkPyFRPipeline::RequestDataDescription(
   return 1;
 }
 
-static void
-output_camera(/*const*/ vtkCamera* cam) {
-  double eye[3] = {0.0};
-  double ref[3] = {0.0};
-  double vup[3] = {0.0};
-  cam->GetPosition(eye);
-  cam->GetFocalPoint(ref);
-  cam->GetViewUp(vup);
-  printf("eye={%lg %lg %lg} ref={%lf %lf %lf} vup={%lf %lf %lf}\n",
-         eye[0],eye[1],eye[2], ref[0],ref[1],ref[2],
-         vup[0],vup[1],vup[2]);
-}
-
+//----------------------------------------------------------------------------
 void vtkPyFRPipeline::SetResolution(uint32_t width, uint32_t height)
 {
   vtkSMSessionProxyManager* sessionProxyManager =

--- a/Source/vtkPyFR/vtkPyFRPipeline.cxx
+++ b/Source/vtkPyFR/vtkPyFRPipeline.cxx
@@ -48,6 +48,7 @@
 #include <vtkTextRepresentation.h>
 #include <vtkVector.h>
 #include <vtkXMLUnstructuredGridReader.h>
+#include <vtkProperty.h>
 
 #include "vtkPyFRData.h"
 #include "vtkPyFRCrinkleClipFilter.h"
@@ -113,6 +114,9 @@ void vtkAddActor(vtkSmartPointer<Mapper> mapper,
 
   vtkNew<vtkActor> actor;
   actor->SetMapper(mapper);
+
+  actor->GetProperty()->SetSpecular(0.5);
+  actor->GetProperty()->SetSpecularPower(25.0);
 
   ren->AddActor(actor.GetPointer());
 }
@@ -637,6 +641,7 @@ int vtkPyFRPipeline::CoProcess(vtkCPDataDescription* dataDescription)
           output_camera(cam);
         }
       );
+
       const int magnification = 1;
       const int quality = 100;
       char fname[32] = {0};

--- a/Source/vtkPyFR/vtkPyFRPipeline.cxx
+++ b/Source/vtkPyFR/vtkPyFRPipeline.cxx
@@ -506,6 +506,34 @@ void vtkPyFRPipeline::SetResolution(uint32_t width, uint32_t height)
 }
 
 //----------------------------------------------------------------------------
+void vtkPyFRPipeline::SetSpecularLighting(float coefficient, float power)
+{
+  vtkSMSessionProxyManager* sessionProxyManager =
+    vtkSMProxyManager::GetProxyManager()->GetActiveSessionProxyManager();
+  vtkNew<vtkCollection> views;
+  sessionProxyManager->GetProxies("views",views.GetPointer());
+  const size_t nviews = views->GetNumberOfItems();
+  for (int i=0; i < nviews; i++)
+    {
+    vtkSMViewProxy* viewProxy =
+      vtkSMViewProxy::SafeDownCast(views->GetItemAsObject(i));
+    vtkSMRenderViewProxy* rview = vtkSMRenderViewProxy::SafeDownCast(viewProxy);
+    vtkRenderer* ren = rview->GetRenderer();
+
+    vtkActorCollection* actors = ren->GetActors();
+    vtkCollectionSimpleIterator ait;
+    actors->InitTraversal(ait);
+
+    vtkActor *actor;
+    while ( (actor = actors->GetNextActor(ait)) )
+      {
+      actor->GetProperty()->SetSpecular(coefficient);
+      actor->GetProperty()->SetSpecularPower(power);
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
 int vtkPyFRPipeline::CoProcess(vtkCPDataDescription* dataDescription)
 {
   vtkSMSessionProxyManager* sessionProxyManager =

--- a/Source/vtkPyFR/vtkPyFRPipeline.h
+++ b/Source/vtkPyFR/vtkPyFRPipeline.h
@@ -29,6 +29,7 @@ public:
   virtual int RequestDataDescription(vtkCPDataDescription* dataDescription);
 
   virtual void SetResolution(uint32_t w, uint32_t h);
+  virtual void SetSpecularLighting(float coefficient, float power);
   virtual int CoProcess(vtkCPDataDescription* dataDescription);
 
   vtkSmartPointer<vtkSMSourceProxy> GetContour() { return this->Contour; }


### PR DESCRIPTION
This contains the changes needed to have the gradient computation properly run, instead of always thinking we have zero points in the input data set.

This also adds default specular lighting, and a "C" api to control the specular controls.
