### PR TITLE
Allow python to control contour field

### DIFF
--- a/Source/PyFR/ColorTable.cu
+++ b/Source/PyFR/ColorTable.cu
@@ -1,10 +1,10 @@
 
 #include "ColorTable.h"
 
-
-
 static ::thrust::system::cuda::vector< Color> PaletteVec;
 static ::thrust::system::cuda::vector< float> PivotsVec;
+static std::vector<Color> RuntimePalette;
+static std::vector<float> RuntimePivots;
 
 RuntimeColorTable::RuntimeColorTable(FPType cmin, FPType cmax,
   const std::vector<Color>& palette,
@@ -34,11 +34,45 @@ RuntimeColorTable::RuntimeColorTable(FPType cmin, FPType cmax,
   this->Palette = (&PaletteVec[0]).get();
   this->Pivots = (&PivotsVec[0]).get();
 
-}
+  std::cout << "RuntimeColorTable being constructed. " << std::endl;
+  std::cout << "RuntimeColorTable->Min: " << this->Min << std::endl;
+  std::cout << "RuntimeColorTable->Max: " << this->Max << std::endl;
+  std::cout << "RuntimeColorTable->NumberOfColors: " << this->NumberOfColors << std::endl;
+  for(std::size_t i=0; i < pivots.size(); ++i)
+  {
+    std::cout <<  "RuntimeColorTable pivots["<<i<<"] = " << unnormalized_pivots[i] << std::endl;
+    std::cout <<  "RuntimeColorTable rgba["<<i<<"] = ("
+              << (int)palette[i][0] << ", "
+              << (int)palette[i][1] << ", "
+              << (int)palette[i][2] << ", "
+              << (int)palette[i][3]
+              << ")"<<std::endl;
+  }
 
+}
 
 void RuntimeColorTable::ReleaseResources()
 {
   PaletteVec.resize(0); PaletteVec.shrink_to_fit();
   PivotsVec.resize(0); PivotsVec.shrink_to_fit();
 }
+
+void fetchRuntimeVectors(std::vector<Color>& palette,
+                         std::vector<float>& pivots)
+{
+  palette = std::vector<Color>(RuntimePalette.begin(), RuntimePalette.end());
+  pivots = std::vector<float>(RuntimePivots.begin(), RuntimePivots.end());
+}
+
+void fillRuntimeVectors(const uint8_t* rgba, const float* loc, size_t n)
+{
+  RuntimePalette.resize(n);
+  RuntimePivots.resize(n);
+
+  for(size_t i=0; i < n; ++i) {
+    RuntimePalette[i] = Color(rgba[i*4+0], rgba[i*4+1], rgba[i*4+2], rgba[i*4+3]);
+    RuntimePivots[i] = loc[i];
+  }
+}
+
+

--- a/Source/PyFR/ColorTable.h
+++ b/Source/PyFR/ColorTable.h
@@ -153,12 +153,15 @@ protected:
   }
 };
 
+void fetchRuntimeVectors(std::vector<Color>&, std::vector<float>&);
+void fillRuntimeVectors(const uint8_t* rgba, const float* loc, size_t n);
+
 static
 RuntimeColorTable make_ColorTable(ColorTable::Preset i,
                                   FPType min, FPType max)
 {
-  static std::vector<Color> palette;
-  static std::vector<float> pivots;
+  std::vector<Color> palette;
+  std::vector<float> pivots;
   vtkm::Id numColors = 0;
 
   switch(i)
@@ -166,8 +169,7 @@ RuntimeColorTable make_ColorTable(ColorTable::Preset i,
     //1. ColorTable need to normalize the pivots after construction
     //based on the min & max
   case ColorTable::RUNTIME:
-    //
-    //Here be where we hack
+    fetchRuntimeVectors(palette,pivots);
     break;
   case ColorTable::COOLTOWARM:
     numColors = 3;
@@ -209,18 +211,6 @@ RuntimeColorTable make_ColorTable(ColorTable::Preset i,
   }
 
   return RuntimeColorTable(min, max, palette, pivots);
-}
-
-static
-RuntimeColorTable make_CustomColorTable(const uint8_t* rgba, const float* loc,
-                                        size_t n, FPType cmin, FPType cmax) {
-  std::vector<Color> palette(n);
-  std::vector<float> pivots(n);
-  for(size_t i=0; i < n; ++i) {
-    palette[i] = Color(rgba[i*4+0], rgba[i*4+1], rgba[i*4+2], rgba[i*4+3]);
-    pivots[i] = loc[i];
-  }
-  return RuntimeColorTable(cmin, cmax, palette, pivots);
 }
 
 #endif

--- a/Source/PyFR/PyFRContourData.cu
+++ b/Source/PyFR/PyFRContourData.cu
@@ -26,10 +26,11 @@ public:
   ContourDataImpl()
   {
     TablePreset = ColorTable::GRAYSCALE;
-    this->Table = make_ColorTable(TablePreset, 0.0, 1.0);
+    this->Table = make_ColorTable(TablePreset,0.0,1.0);
   }
 
   ColorTable::Preset TablePreset;
+
   RuntimeColorTable Table;
   std::vector<PyFRContour> Contours;
 };
@@ -38,8 +39,6 @@ public:
 PyFRContourData::PyFRContourData()
 {
   this->Impl = new ContourDataImpl;
-  this->crange[0] = FLT_MAX;
-  this->crange[1] = FLT_MIN;
 }
 
 //----------------------------------------------------------------------------
@@ -161,25 +160,6 @@ void PyFRContourData::SetColorRange(FPType min,FPType max)
   this->SetColorPalette(this->Impl->TablePreset,
                         min,
                         max);
-  this->crange[0] = min;
-  this->crange[1] = max;
-}
-
-void PyFRContourData::SetCustomColorTable(const uint8_t* rgba, const float* loc,
-                                          size_t n)
-{
-	if(this->crange[0] == FLT_MAX || this->crange[1] == FLT_MIN)
-    {
-      throw std::runtime_error("SetColorRange not yet called!  You need to set"
-                               " the color range before you can setup a custom"
-                               " color table.");
-    }
-  this->Impl->Table = make_CustomColorTable(rgba, loc, n, this->crange[0],
-                                            this->crange[1]);
-  for (unsigned i=0;i<this->GetNumberOfContours();i++)
-    {
-    this->Impl->Contours[i].ChangeColorTable(this->Impl->Table);
-    }
 }
 
 namespace transfer

--- a/Source/PyFR/PyFRContourData.h
+++ b/Source/PyFR/PyFRContourData.h
@@ -24,12 +24,10 @@ public:
 
   void SetColorPreset(int);
   void SetColorRange(FPType,FPType);
-  void SetCustomColorTable(const uint8_t* rgba, const float* loc, size_t n);
 
 private:
   class ContourDataImpl;
   ContourDataImpl* Impl;
-  FPType crange[2];
 };
 
 

--- a/Source/vtkPyFR/vtkPyFRAdaptor.cxx
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.cxx
@@ -159,6 +159,32 @@ void CatalystSetColorRange(void*, double low, double high)
 }
 
 //----------------------------------------------------------------------------
+void CatalystSetFieldToContourBy(int field)
+{
+  if(Processor == NULL)
+    {
+    fprintf(stderr, "%s: catalyst not initialized!\n", __FUNCTION__);
+    return;
+    }
+  vtkPyFRPipeline* pipeline =
+    vtkPyFRPipeline::SafeDownCast(Processor->GetPipeline(0));
+  pipeline->SetFieldToContourBy(field);
+}
+
+//----------------------------------------------------------------------------
+void CatalystSetFieldToColorBy(int field)
+{
+  if(Processor == NULL)
+    {
+    fprintf(stderr, "%s: catalyst not initialized!\n", __FUNCTION__);
+    return;
+    }
+  vtkPyFRPipeline* pipeline =
+    vtkPyFRPipeline::SafeDownCast(Processor->GetPipeline(0));
+  pipeline->SetFieldToColorBy(field);
+}
+
+//----------------------------------------------------------------------------
 void CatalystFinalize(void* p)
 {
   vtkPyFRData* data = static_cast<vtkPyFRData*>(p);

--- a/Source/vtkPyFR/vtkPyFRAdaptor.h
+++ b/Source/vtkPyFR/vtkPyFRAdaptor.h
@@ -27,6 +27,23 @@ extern "C"
   void CatalystSetColorTable(void*, const uint8_t* rgba, const float* loc,
                              size_t n);
   void CatalystSetColorRange(void*, double low, double high);
+
+  //Fields:
+  //0 = "density";
+  //1 = "pressure";
+  //2 = "velocity_u";
+  //3 = "velocity_v";
+  //4 = "velocity_w";
+  //5 = "density_gradient_magnitude";
+  //6 = "pressure_gradient_magnitude";
+  //7 = "velocity_gradient_magnitude";
+  //8 = "velocity_qcriterion";
+  //
+  void CatalystSetFieldToContourBy(int field);
+
+  void CatalystSetFieldToColorBy(int field);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/vtkPyFR/vtkPyFRContourData.cxx
+++ b/Source/vtkPyFR/vtkPyFRContourData.cxx
@@ -169,13 +169,5 @@ void vtkPyFRContourData::SetColorRange(FPType low, FPType high)
   this->Modified();
 }
 
-void vtkPyFRContourData::SetCustomColorPalette(const uint8_t* rgba,
-                                               const float* loc, size_t n)
-{
-  this->data->SetNumberOfContours(n);
-  this->data->SetCustomColorTable(rgba, loc, n);
-  this->Modified();
-}
-
 //----------------------------------------------------------------------------
 vtkObject* New_vtkPyFRContourData() { return vtkPyFRContourData::New(); }

--- a/Source/vtkPyFR/vtkPyFRContourData.h
+++ b/Source/vtkPyFR/vtkPyFRContourData.h
@@ -34,7 +34,6 @@ public:
   void SetColorPalette(int,double*);
   void SetColorPreset(int);
   void SetColorRange(FPType, FPType);
-  void SetCustomColorPalette(const uint8_t* rgba, const float* loc, size_t n);
 
 protected:
   vtkPyFRContourData();

--- a/Source/vtkPyFR/vtkPyFRContourFilter.cxx
+++ b/Source/vtkPyFR/vtkPyFRContourFilter.cxx
@@ -30,7 +30,7 @@ int vtkPyFRContourFilter::PyFRDataTypesRegistered =
 vtkStandardNewMacro(vtkPyFRContourFilter);
 
 //----------------------------------------------------------------------------
-vtkPyFRContourFilter::vtkPyFRContourFilter() : ContourField(0)
+vtkPyFRContourFilter::vtkPyFRContourFilter()
 {
   this->ColorPaletteNeedsSyncing = false;
   this->ColorPalette = 1;
@@ -57,7 +57,7 @@ void vtkPyFRContourFilter::SetColorPalette(int palette)
 //----------------------------------------------------------------------------
 void vtkPyFRContourFilter::SetColorRange(double start, double end)
 {
-  if(start != this->ColorRange[0] && end != this->ColorRange[1])
+  if(start != this->ColorRange[0] || end != this->ColorRange[1])
   {
     this->Modified();
     this->ColorPaletteNeedsSyncing = true;
@@ -101,7 +101,9 @@ int vtkPyFRContourFilter::RequestData(
                                  output->GetData());
 
   std::pair<float,float> crange = filter.ColorRange();
+  std::cout << "Coloring contour with field: " << this->MappedField << std::endl;
   std::cout << "Contour color range is: " << ColorRange[0] << " to " << ColorRange[1] << std::endl;
+  std::cout << "Input contour color field range:" << crange.first << " to " << crange.second << std::endl;
 
   this->minmax = filter.DataRange();
   output->Modified();
@@ -132,8 +134,8 @@ void vtkPyFRContourFilter::SetContourValue(int i,double value)
     this->Modified();
     }
 }
-//----------------------------------------------------------------------------
 
+//----------------------------------------------------------------------------
 void vtkPyFRContourFilter::SetContourField(int i)
 {
   if (this->ContourField != i)
@@ -142,14 +144,16 @@ void vtkPyFRContourFilter::SetContourField(int i)
     this->Modified();
     }
 }
-//----------------------------------------------------------------------------
 
+//----------------------------------------------------------------------------
 void vtkPyFRContourFilter::SetMappedField(int i)
 {
   if (this->MappedField != i)
     {
+    std::cout << "vtkPyFRContourFilter Setting field to color by : " << i << std::endl;
     this->MappedField = i;
     this->Modified();
+    this->ColorPaletteNeedsSyncing = true;
     }
 }
 //----------------------------------------------------------------------------

--- a/Source/vtkPyFR/vtkPyFRParallelSliceFilter.cxx
+++ b/Source/vtkPyFR/vtkPyFRParallelSliceFilter.cxx
@@ -65,7 +65,7 @@ void vtkPyFRParallelSliceFilter::SetColorPalette(int palette)
 //----------------------------------------------------------------------------
 void vtkPyFRParallelSliceFilter::SetColorRange(double start, double end)
 {
-  if(start != this->ColorRange[0] && end != this->ColorRange[1])
+  if(start != this->ColorRange[0] || end != this->ColorRange[1])
   {
     this->Modified();
     this->ColorPaletteNeedsSyncing = true;

--- a/Source/vtkPyFR/vtkPyFRPipeline.cxx
+++ b/Source/vtkPyFR/vtkPyFRPipeline.cxx
@@ -542,9 +542,35 @@ void vtkPyFRPipeline::SetColorRange(FPType low, FPType high)
 {
   vtkObjectBase* obj = this->Contour->GetClientSideObject();
   vtkPyFRContourFilter* filt = vtkPyFRContourFilter::SafeDownCast(obj);
-  vtkPyFRContourData* cdata = filt->GetOutput();
-  // -1 is ColorTable::RUNTIME; we can't include that header.
-  cdata->SetColorRange(low, high);
+
+  filt->SetColorRange(low,high);
+}
+
+void vtkPyFRPipeline::SetFieldToContourBy(int field)
+{
+  if(this->Contour)
+  {
+    vtkSMPropertyHelper(this->Contour,"ContourField").Set(field);
+    this->Contour->UpdatePropertyInformation();
+    this->Contour->UpdateVTKObjects();
+  }
+}
+
+void vtkPyFRPipeline::SetFieldToColorBy(int field)
+{
+  if(this->Contour)
+  {
+    std::cout << "vtkPyFRPipeline::SetFieldToColorBy: " << field << std::endl;
+    vtkSMPropertyHelper(this->Contour,"ColorField").Set(field);
+    this->Contour->UpdatePropertyInformation();
+    this->Contour->UpdateVTKObjects();
+  }
+  if(this->Slice)
+  {
+    vtkSMPropertyHelper(this->Slice,"ColorField").Set(field);
+    this->Contour->UpdatePropertyInformation();
+    this->Slice->UpdateVTKObjects();
+  }
 }
 
 //----------------------------------------------------------------------------

--- a/Source/vtkPyFR/vtkPyFRPipeline.cxx
+++ b/Source/vtkPyFR/vtkPyFRPipeline.cxx
@@ -526,15 +526,16 @@ void vtkPyFRPipeline::SetSpecularLighting(float coefficient, float power)
     }
 }
 
+void fillRuntimeVectors(const uint8_t* rgba, const float* loc, size_t n);
+
 void vtkPyFRPipeline::SetColorTable(const uint8_t* rgba, const float* loc,
                                     size_t n)
 {
+  fillRuntimeVectors(rgba, loc, n);
+  // -1 is ColorTable::RUNTIME; we can't include that header.
   vtkObjectBase* obj = this->Contour->GetClientSideObject();
   vtkPyFRContourFilter* filt = vtkPyFRContourFilter::SafeDownCast(obj);
-  vtkPyFRContourData* cdata = filt->GetOutput();
-  // -1 is ColorTable::RUNTIME; we can't include that header.
-  cdata->SetColorPreset(-1);
-  cdata->SetCustomColorPalette(rgba, loc, n);
+  filt->SetColorPalette(-1);
 }
 
 void vtkPyFRPipeline::SetColorRange(FPType low, FPType high)

--- a/Source/vtkPyFR/vtkPyFRPipeline.h
+++ b/Source/vtkPyFR/vtkPyFRPipeline.h
@@ -31,8 +31,12 @@ public:
   virtual void SetResolution(uint32_t w, uint32_t h);
   virtual void SetSpecularLighting(float coefficient, float power);
   virtual int CoProcess(vtkCPDataDescription* dataDescription);
+
   virtual void SetColorTable(const uint8_t* rgba, const float* loc, size_t n);
   virtual void SetColorRange(FPType, FPType);
+
+  virtual void SetFieldToContourBy(int);
+  virtual void SetFieldToColorBy(int);
 
   vtkSmartPointer<vtkSMSourceProxy> GetContour() { return this->Contour; }
   vtkSmartPointer<vtkSMSourceProxy> GetSlice()   { return this->Slice;   }


### PR DESCRIPTION
This fixes issues with runtime color tables never being applied.

This also allows the python plugin to specify what fields to contour and color the contour by.

```
        self.catalyst.CatalystSetFieldToContourBy(0)
        self.catalyst.CatalystSetFieldToColorBy(4)
```
